### PR TITLE
cc.EditBoxDelegate fix

### DIFF
--- a/script/jsb.js
+++ b/script/jsb.js
@@ -54,6 +54,13 @@ if (window.ccs) {
 }
 
 if (window.ccui) {
+    cc.EditBoxDelegate = cc.Class.extend({
+        editBoxEditingDidBegin: function (sender) {},
+        editBoxEditingDidEnd: function (sender) {},
+        editBoxTextChanged: function (sender, text) {},
+        editBoxReturn: function (sender) {}
+    });
+
     // move from jsb_boot.js line 912
     //start------------------------------
     cc.EditBox = ccui.EditBox;


### PR DESCRIPTION
`JSB_EditBoxDelegate` and `cc.EditBox.setDelegate` were implemented in C++. Right now, `setDelegate` can receive a simple plain object and it works perfectly, but the `cc.EditBoxDelegate` object that exists in HTML5 doesn't exist in JSB. I'm simply creating it the way it is created in HTML5.
